### PR TITLE
Fix README.md to use yarn add

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install the [npm package](https://www.npmjs.com/package/bootstrap-darkmode):
 
 ```sh
 $ npm install bootstrap-darkmode
-$ yarn install bootstrap-darkmode
+$ yarn add bootstrap-darkmode
 $ pnpm install bootstrap-darkmode
 ```
 


### PR DESCRIPTION
The readme instructions were failing on:
```
$ yarn install bootstrap-darkmode
yarn install v1.22.5
error `install` has been replaced with `add` to add new dependencies. Run "yarn add bootstrap-darkmode" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```