### PR TITLE
Export ThemeConfig and writeDarkSwitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Include the stylesheet, e.g. in `styles.scss`:
 @import "~bootstrap-darkmode/darktheme";
 ```
 
+import the control functions, e.g. in `main.ts`:
+
+```js
+import { ThemeConfig, writeDarkSwitch } from 'bootstrap-darkmode/theme';
+```
+
 ### Via unpkg.com
 
 1. Put the stylesheet link in `<head>`. Do not forget to add bootstrap.

--- a/theme.ts
+++ b/theme.ts
@@ -1,4 +1,4 @@
-class ThemeConfig {
+export class ThemeConfig {
     themeChangeHandlers: ((theme: string) => void)[] = [];
 
     loadTheme(): string | null {
@@ -39,7 +39,7 @@ class ThemeConfig {
     }
 }
 
-function writeDarkSwitch(config: ThemeConfig) {
+export function writeDarkSwitch(config: ThemeConfig) {
     document.write(`
 <div class="custom-control custom-switch">
 <input type="checkbox" class="custom-control-input" id="darkSwitch">


### PR DESCRIPTION
This change allows that `ThemeConfig` and `writeDarkSwitch` can be imported in a project that uses bootstrap-darkmode by
```js
import { ThemeConfig, writeDarkSwitch } from 'bootstrap-darkmode/theme';
```

I'm probably missing something, because from the [README With NPM/Yarn/PNPM
section](https://github.com/Clashsoft/bootstrap-darkmode#with-npmyarnpnpm) I don't see how the import could work. The above code snippet, is how I would expect this to work. 

One further step would be to rename `theme.ts` to `index.ts`, so that the import can be just `[...] from 'bootstrap-darkmode'`. But I didn't want to go that far, since I feel like I'm missing some context here.

I'm not familiar with how https://unpkg.com/ works, so please make sure this change doesn't break https://unpkg.com/ 