### PR TITLE
Override colors for additive border classes

### DIFF
--- a/src/darktheme.scss
+++ b/src/darktheme.scss
@@ -350,6 +350,14 @@ $form-addon-bg: $default-header-bg;
 		background-color: $window-bg;
 		border-color: $card-border;
 	}
+
+	// --------------- Borders ---------------
+
+	.border { border-color: $default-border; }
+	.border-top { border-top-color: $default-border; }
+	.border-right { border-right-color: $default-border; }
+	.border-bottom { border-bottom-color: $default-border; }
+	.border-left { border-left-color: $default-border; }
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## New Features

+ Added color overrides for the `border-*` classes. #18

Closes #18